### PR TITLE
chore(package.json): fix delvedor's personal url

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/fastify/fastify-citgm.git"
   },
   "keywords": [],
-  "author": "Tomas Della Vedova - @delvedor (http://delved.org)",
+  "author": "Tomas Della Vedova - @delvedor (https://delvedor.dev)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/fastify/fastify-citgm/issues"


### PR DESCRIPTION
Old link no longer exists