### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ If you feel you can help in any way, be it with examples, extra testing, or new 
 
 
 ## Acknowledgements
-This project is kindly sponsored by:
-- [LetzDoIt](https://www.letzdoitapp.com/)
+
+Past sponsors:
+- LetzDoIt
 
 ## License
 **[MIT](https://github.com/fastify/fastify-citgm/blob/main/LICENSE)**


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71